### PR TITLE
Also set selinux on cache directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,11 +111,21 @@ class cachefilesd (
   }
 
   if $manage_dir {
+    $selentries = split($secctx, ':')
+    $seluser = $selentries[0]
+    $selrole = $selentries[1]
+    $seltype = $selentries[2]
+    $selrange = $selentries[3]
+
     file { $dir:
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0755',
+      ensure   => 'directory',
+      owner    => 'root',
+      group    => 'root',
+      mode     => '0755',
+      seluser  => $seluser,
+      selrole  => $selrole,
+      seltype  => $seltype,
+      selrange => $selrange,
     }
     if $manage_service {
       File[$dir] ~> Service['cachefilesd']

--- a/spec/classes/cachefilesd_spec.rb
+++ b/spec/classes/cachefilesd_spec.rb
@@ -24,6 +24,10 @@ describe 'cachefilesd' do
           owner: 'root',
           group: 'root',
           mode: '0755',
+          seluser: 'system_u',
+          selrole: 'system_r',
+          seltype: 'cachefiles_kernel_t',
+          selrange: 's0',
         )
       end
 


### PR DESCRIPTION
If for some reason someone changes the selinux context, the cache dir should be updated to match.