### PR TITLE
Update SELinux context

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -177,7 +177,7 @@ Data type: `String[1]`
 
 cachefilesd `secctx` config option
 
-Default value: `'system_u:system_r:cachefiles_kernel_t:s0'`
+Default value: `'system_u:object_r:cachefiles_var_t:s0'`
 
 ##### <a name="culltable"></a>`culltable`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,7 +14,7 @@ cachefilesd::bstop: 3
 cachefilesd::frun: 10
 cachefilesd::fcull: 7
 cachefilesd::fstop: 3
-cachefilesd::secctx: system_u:system_r:cachefiles_kernel_t:s0
+cachefilesd::secctx: system_u:object_r:cachefiles_var_t:s0
 cachefilesd::culltable: 12
 cachefilesd::nocull: false
 # cachefilesd::resume_thresholds

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,7 @@ class cachefilesd (
   Integer[0,99] $frun = 10,
   Integer[0,99] $fcull = 7,
   Integer[0,99] $fstop = 3,
-  String[1] $secctx = 'system_u:system_r:cachefiles_kernel_t:s0',
+  String[1] $secctx = 'system_u:object_r:cachefiles_var_t:s0',
   Integer[12,20] $culltable = 12,
   Boolean $nocull = false,
   Optional[String[1]] $resume_thresholds = undef,

--- a/spec/classes/cachefilesd_spec.rb
+++ b/spec/classes/cachefilesd_spec.rb
@@ -25,8 +25,8 @@ describe 'cachefilesd' do
           group: 'root',
           mode: '0755',
           seluser: 'system_u',
-          selrole: 'system_r',
-          seltype: 'cachefiles_kernel_t',
+          selrole: 'object_r',
+          seltype: 'cachefiles_var_t',
           selrange: 's0',
         )
       end
@@ -55,7 +55,7 @@ describe 'cachefilesd' do
           'frun 10%',
           'fcull 7%',
           'fstop 3%',
-          'secctx system_u:system_r:cachefiles_kernel_t:s0',
+          'secctx system_u:object_r:cachefiles_var_t:s0',
           'culltable 12',
         ]
         verify_contents(catalogue, 'cachefilesd.conf', expected)


### PR DESCRIPTION
The SELinux `system_r` role and `cachefilesd_kernel_t` type are intended for processes, not for files. 
Using the `object_r` role and `cachefilesd_var_t` type is more appropriate. 

It seems that RHEL 7 allows for process contexts to be used on files, but RHEL 8 does not. 
Attempting to set `system_r` and `cachefilesd_kernel_t` on RHEL 8 results in an `invalid argument` and `permission denied` error respectively. Using the appropriate context should work on RHEL 8. 

Note that `system_u:object_r:cachefiles_var_t:s0` is also the default context when the `cachefilesd` package is installed. 