### PR TITLE
Add filesecctx argument to separate file context from process context

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -33,6 +33,7 @@ The following parameters are available in the `cachefilesd` class:
 * [`manage_config`](#manage_config)
 * [`config_path`](#config_path)
 * [`manage_dir`](#manage_dir)
+* [`filesecctx`](#filesecctx)
 * [`dir`](#dir)
 * [`cache_tag`](#cache_tag)
 * [`brun`](#brun)
@@ -106,6 +107,14 @@ Data type: `Boolean`
 Booleans that determines if `dir` resource is managed.
 
 Default value: ``true``
+
+##### <a name="filesecctx"></a>`filesecctx`
+
+Data type: `String[1]`
+
+SELinux security context for the `dir` resource
+
+Default value: ``system_u:object_r:cachefiles_var_t:s0``
 
 ##### <a name="dir"></a>`dir`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,7 +14,8 @@ cachefilesd::bstop: 3
 cachefilesd::frun: 10
 cachefilesd::fcull: 7
 cachefilesd::fstop: 3
-cachefilesd::secctx: system_u:object_r:cachefiles_var_t:s0
+cachefilesd::secctx: system_u:system_r:cachefiles_kernel_t:s0
+cachefilesd::filesecctx: system_u:object_r:cachefiles_var_t:s0
 cachefilesd::culltable: 12
 cachefilesd::nocull: false
 # cachefilesd::resume_thresholds

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@
 #   Path to cachefilesd.conf
 # @param manage_dir
 #   Booleans that determines if `dir` resource is managed.
+# @param filesecctx
+#   SELinux security context for the `dir` resource
 # @param dir
 #   cachefilesd `dir` config option
 # @param cache_tag
@@ -60,6 +62,7 @@ class cachefilesd (
   Boolean $manage_config = true,
   Stdlib::Absolutepath $config_path = '/etc/cachefilesd.conf',
   Boolean $manage_dir = true,
+  String[1] $filesecctx = 'system_u:object_r:cachefiles_var_t:s0',
   Stdlib::Absolutepath $dir = '/var/cache/fscache',
   Variant[String[1], Boolean] $cache_tag = 'CacheFiles',
   Integer[0,99] $brun = 10,
@@ -68,7 +71,7 @@ class cachefilesd (
   Integer[0,99] $frun = 10,
   Integer[0,99] $fcull = 7,
   Integer[0,99] $fstop = 3,
-  String[1] $secctx = 'system_u:object_r:cachefiles_var_t:s0',
+  String[1] $secctx = 'system_u:system_r:cachefiles_kernel_t:s0',
   Integer[12,20] $culltable = 12,
   Boolean $nocull = false,
   Optional[String[1]] $resume_thresholds = undef,
@@ -139,7 +142,7 @@ class cachefilesd (
   }
 
   if $manage_dir {
-    $selentries = split($secctx, ':')
+    $selentries = split($filesecctx, ':')
     $seluser = $selentries[0]
     $selrole = $selentries[1]
     $seltype = $selentries[2]

--- a/spec/classes/cachefilesd_spec.rb
+++ b/spec/classes/cachefilesd_spec.rb
@@ -55,7 +55,7 @@ describe 'cachefilesd' do
           'frun 10%',
           'fcull 7%',
           'fstop 3%',
-          'secctx system_u:object_r:cachefiles_var_t:s0',
+          'secctx system_u:system_r:cachefiles_kernel_t:s0',
           'culltable 12',
         ]
         verify_contents(catalogue, 'cachefilesd.conf', expected)


### PR DESCRIPTION
This is a followup PR to #17 which fixes an issue caused by the changes made there. 

In the original PR, the SELinux context was changed from a process context to a file context, since it was used to set the file context on the directory resource. However, this same value is used in the cachefilesd config file to set the process context. 

Upon changing the value to a process context, this caused the process to abort shortly after starting. 

This PR adds a new argument which is used to control the directory context, and reverts the original process context back to its original value. This allows for a clean puppet run which correctly sets the context on the directory, and also allows the service to start successfully. 